### PR TITLE
Add 3-column responsive HML layouts for remaining languages

### DIFF
--- a/HML/de_DE/Antwort dreispaltig (5313).html
+++ b/HML/de_DE/Antwort dreispaltig (5313).html
@@ -1,0 +1,232 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="UTF-8"><!-- Facebook sharing information tags --><meta property="og:title" content="{{Subject}}" />
+
+    <title>{{Subject}}</title>
+</head>
+
+<body bgcolor="#FAFAFA" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; height: 100% !important; width: 100% !important; background-color: #FAFAFA; margin: 0; padding: 0;">
+    <style type="text/css">
+      #outlook a {
+          padding: 0;
+      }
+      .body{
+          width: 100% !important;
+          -webkit-text-size-adjust: 100%;
+          -ms-text-size-adjust: 100%;
+          margin: 0;
+          padding: 0;
+      }
+      .ExternalClass {
+          width:100%;
+      }
+      .ExternalClass,
+      .ExternalClass p,
+      .ExternalClass span,
+      .ExternalClass font,
+      .ExternalClass td,
+      .ExternalClass div {
+          line-height: 100%;
+      }
+      img {
+          outline: none;
+          text-decoration: none;
+          -ms-interpolation-mode: bicubic;
+      }
+      a img {
+          border: none;
+      }
+      p {
+          margin: 1em 0;
+      }
+      table td {
+          border-collapse: collapse;
+      }
+      /* hide unsubscribe from forwards*/
+      blockquote .original-only, .WordSection1 .original-only {
+        display: none !important;
+      }
+
+      @media only screen and (max-width: 480px){
+        body, table, td, p, a, li, blockquote{-webkit-text-size-adjust:none !important;} /* Prevent Webkit platforms from changing default text sizes */
+                body{width:100% !important; min-width:100% !important;} /* Prevent iOS Mail from adding padding to the body */
+
+        #bodyCell{padding:10px !important;}
+
+        #templateContainer{
+          max-width:600px !important;
+          width:100% !important;
+        }
+
+        h1{
+          font-size:24px !important;
+          line-height:100% !important;
+        }
+
+        h2{
+          font-size:20px !important;
+          line-height:100% !important;
+        }
+
+        h3{
+          font-size:18px !important;
+          line-height:100% !important;
+        }
+
+        h4{
+          font-size:16px !important;
+          line-height:100% !important;
+        }
+
+        #templatePreheader{display:none !important;} /* Hide the template preheader to save space */
+
+        #headerImage{
+          height:auto !important;
+          max-width:600px !important;
+          width:100% !important;
+        }
+
+        .headerContent{
+          font-size:20px !important;
+          line-height:125% !important;
+        }
+
+        .bodyContent{
+          font-size:18px !important;
+          line-height:125% !important;
+        }
+
+        .templateColumnContainer{display:block !important; width:100% !important;}
+
+        .columnImage{
+          height:auto !important;
+          max-width:480px !important;
+          width:100% !important;
+        }
+
+        .leftColumnContent{
+          font-size:16px !important;
+          line-height:125% !important;
+        }
+
+        .centerColumnContent{
+          font-size:16px !important;
+          line-height:125% !important;
+        }
+
+        .rightColumnContent{
+          font-size:16px !important;
+          line-height:125% !important;
+        }
+
+        .footerContent{
+          font-size:14px !important;
+          line-height:115% !important;
+        }
+
+        .footerContent a{display:block !important;} /* Place footer social and utility links on their own lines, for easier access */
+      }
+    </style>
+
+    <table align="center" border="0" cellpadding="0" cellspacing="0" id="bodyTable" style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #FAFAFA; border-collapse: collapse !important; height: 100% !important; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding: 0; width: 100% !important" width="100%">
+        <tr>
+            <td align="center" id="bodyCell" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; height: 100% !important; width: 100% !important; border-top-width: 4px; border-top-color: #dddddd; border-top-style: solid; margin: 0; padding: 20px;" valign="top"><!-- BEGIN TEMPLATE // --><table border="0" cellpadding="0" cellspacing="0" id="templateContainer" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important; width: 600px; border: 1px solid #dddddd;">
+                    <tr>
+                        <td align="center" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt;" valign="top"><!-- BEGIN PREHEADER // --><table border="0" cellpadding="0" cellspacing="0" id="templatePreheader" style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #FFFFFF; border-bottom-color: #CCCCCC; border-bottom-style: solid; border-bottom-width: 1px; border-collapse: collapse !important; mso-table-lspace: 0pt; mso-table-rspace: 0pt" width="100%">
+                                <tr>
+                                    <td pardot-region="preheader_content00" align="left" class="preheaderContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #808080; font-family: Helvetica; font-size: 10px; line-height: 12.5px; text-align: left; padding: 10px 20px;" valign="top">Nutzen Sie diesen Bereich, um einen kurzen Vorgeschmack auf den Inhalt Ihrer E-Mail zu geben. Dieser Text wird im Vorschaubereich einiger E-Mail-Clients angezeigt.</td>
+
+                                    <td pardot-region="preheader_content01" align="left" class="preheaderContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #808080; font-family: Helvetica; font-size: 10px; line-height: 12.5px; text-align: left; padding: 10px 20px 10px 0;" valign="top" width="180">Wird die E-Mail nicht korrekt angezeigt?<br /> <a href="{{View_Online}}" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #606060; font-weight: normal; text-decoration: underline;" target="_blank">Betrachten Sie sie in Ihrem Browser</a>.</td>
+                                </tr>
+                            </table><!-- // END PREHEADER --></td>
+                    </tr>
+
+                    <tr>
+                        <td align="center" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt;" valign="top"><!-- BEGIN HEADER // --><table border="0" cellpadding="0" cellspacing="0" id="templateHeader" style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #FFFFFF; border-bottom-color: #CCCCCC; border-bottom-style: solid; border-bottom-width: 1px; border-collapse: collapse !important; mso-table-lspace: 0pt; mso-table-rspace: 0pt" width="100%">
+                                <tr pardot-repeatable="">
+                                    <td pardot-region="header_image" align="left" class="headerContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 20px; font-weight: bold; line-height: 20px; text-align: left; vertical-align: middle; padding: 0;" valign="top"><img id="headerImage" src="/images/placeholder.php?width=600&amp;height=150" style="max-width: 600px; -ms-interpolation-mode: bicubic; height: auto; outline: none; text-decoration: none; border: 0;" alt="" /></td>
+                                </tr>
+                            </table><!-- // END HEADER --></td>
+                    </tr>
+
+                    <tr>
+                        <td align="center" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt;" valign="top"><!-- BEGIN BODY // --><table border="0" cellpadding="0" cellspacing="0" id="templateBody" style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #FFFFFF; border-bottom-color: #CCCCCC; border-bottom-style: solid; border-bottom-width: 1px; border-collapse: collapse !important; border-top-color: #FFFFFF; border-top-style: solid; border-top-width: 1px; mso-table-lspace: 0pt; mso-table-rspace: 0pt" width="100%">
+                                <tr pardot-repeatable="">
+                                    <td pardot-region="body_content" align="left" class="bodyContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 16px; line-height: 24px; text-align: left; padding: 20px;" valign="top">
+                                        <h1 style="color: #202020 !important; display: block; font-family: Helvetica; font-size: 26px; font-style: normal; font-weight: bold; letter-spacing: normal; line-height: 26px; margin: 0; padding-bottom:10px; text-align: left">Gestalten der Vorlage</h1>
+
+                                        <h3 style="color: #606060 !important; display: block; font-family: Helvetica; font-size: 16px; font-style: italic; font-weight: normal; letter-spacing: normal; line-height: 16px; margin: 0; padding-bottom:10px; text-align: left">Das Erstellen einer gut aussehenden E-Mail ist einfach</h3>Passen Sie Ihre Vorlage an, indem Sie auf der rechten Seite auf die Registerkarten zum Bearbeiten von Stilen klicken. Legen Sie die gewünschten Schriften, Farben und Stile fest. Nachdem Sie alle Einstellungen vorgenommen haben, können Sie hier in diesen Bereich klicken, den Text löschen und eigenen fantastischen Inhalt hinzufügen.<br /> <br /><h2 style="color: #404040 !important; display: block; font-family: Helvetica; font-size: 20px; font-style: normal; font-weight: bold; letter-spacing: normal; line-height: 20px; margin: 0; padding-bottom:10px; text-align: left">Gestalten des Inhalts</h2>
+
+                                        <h4 style="color: #808080 !important; display: block; font-family: Helvetica; font-size: 14px; font-style: italic; font-weight: normal; letter-spacing: normal; line-height: 14px; margin: 0; padding-bottom:10px; text-align: left">Gestalten Sie Ihre E-Mail leicht lesbar</h4>Wenn Sie Ihren Inhalt eingegeben haben, markieren Sie den zu gestaltenden Text und wählen die Optionen, die Sie im Stil-Editor auf der Registerkarte &apos;<em>Stile</em>&apos; festgelegt haben. Möchten Sie <a href="#" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #336699; font-weight: normal; text-decoration: underline;">die Formatierung eines Textabschnitts entfernen</a>, haben damit aber Schwierigkeiten? Verwenden Sie einfach die Schaltfläche zum <em>Entfernen von Formatierung</em>, um jegliche Formatierung des Texts zu entfernen und den Stil zurückzusetzen.</td>
+                                </tr>
+                            </table><!-- // END BODY --></td>
+                    </tr>
+
+                    <tr>
+                        <td align="center" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt;" valign="top"><!-- BEGIN COLUMNS // --><table border="0" cellpadding="0" cellspacing="0" id="templateColumns" style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #FFFFFF; border-bottom-color: #CCCCCC; border-bottom-style: solid; border-bottom-width: 1px; border-collapse: collapse !important; border-top-color: #FFFFFF; border-top-style: solid; border-top-width: 1px; mso-table-lspace: 0pt; mso-table-rspace: 0pt" width="100%">
+                                <tr pardot-repeatable="">
+                                    <td align="center" class="templateColumnContainer" style="padding-top: 20px; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 200px;" valign="top">
+                                        <table border="0" cellpadding="20" cellspacing="0" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;" width="100%">
+                                            <tr>
+                                                <td pardot-region="left_content_image" align="left" class="leftColumnContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 14px; line-height: 21px; text-align: left; padding: 0 20px 20px;"><img class="columnImage" src="/images/placeholder.php?width=160&amp;height=120" style="max-width: 160px; -ms-interpolation-mode: bicubic; height: auto; outline: none; text-decoration: none; display: inline; border: 0;" alt="" /></td>
+                                            </tr>
+
+                                            <tr>
+                                                <td pardot-region="left_column_content" align="left" class="leftColumnContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 14px; line-height: 21px; text-align: left; padding: 0 20px 20px;" valign="top">
+                                                    <h3 style="color: #606060 !important; display: block; font-family: Helvetica; font-size: 16px; font-style: italic; font-weight: normal; letter-spacing: normal; line-height: 16px; margin: 0; padding-bottom:10px; text-align: left">Wiederholbarer Inhalt</h3><strong>Wiederholbare Inhaltsblöcke:</strong> Bewegen Sie den Mauszeiger über den Dropdown-Pfeil in der oberen rechten Ecke eines Bereichs, um ein Menü mit dafür spezifischen Optionen wie &apos;Kopieren&apos;, &apos;Zeile nach oben verschieben&apos; oder &apos;Löschen&apos; einzublenden. Sie können auch <a href="#" style="color: #336699; font-weight: normal; text-decoration: underline; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%;" target="_blank">etwas von der Norm abweichen</a>: Verwenden Sie Blöcke wiederholt und entfernen Sie den gesamten Text, um &apos;Galerie&apos;-Abschnitte mit Bildern zu erstellen, oder tun Sie das Gegenteil und entfernen Sie Bilder, um reine Textblöcke zu schaffen!</td>
+                                            </tr>
+                                        </table>
+                                    </td>
+
+                                    <td align="center" class="templateColumnContainer" style="padding-top: 20px; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 200px;" valign="top">
+                                        <table border="0" cellpadding="20" cellspacing="0" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;" width="100%">
+                                            <tr>
+                                                <td pardot-region="center_column_image" align="left" class="centerColumnContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 14px; line-height: 21px; text-align: left; padding: 0 20px 20px;"><img class="columnImage" src="/images/placeholder.php?width=160&amp;height=120" style="max-width: 160px; -ms-interpolation-mode: bicubic; height: auto; outline: none; text-decoration: none; border: 0;" alt="" /></td>
+                                            </tr>
+
+                                            <tr>
+                                                <td pardot-region="center_column_content" align="left" class="centerColumnContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 14px; line-height: 21px; text-align: left; padding: 0 20px 20px;" valign="top">
+                                                    <h3 style="color: #606060 !important; display: block; font-family: Helvetica; font-size: 16px; font-style: italic; font-weight: normal; letter-spacing: normal; line-height: 16px; margin: 0; padding-bottom:10px; text-align: left">Wiederholbarer Inhalt</h3><strong>Wiederholbare Inhaltsblöcke:</strong> Bewegen Sie den Mauszeiger über den Dropdown-Pfeil in der oberen rechten Ecke eines Bereichs, um ein Menü mit dafür spezifischen Optionen wie &apos;Kopieren&apos;, &apos;Zeile nach oben verschieben&apos; oder &apos;Löschen&apos; einzublenden. Sie können auch <a href="#" style="color: #336699; font-weight: normal; text-decoration: underline; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%;" target="_blank">etwas von der Norm abweichen</a>: Verwenden Sie Blöcke wiederholt und entfernen Sie den gesamten Text, um &apos;Galerie&apos;-Abschnitte mit Bildern zu erstellen, oder tun Sie das Gegenteil und entfernen Sie Bilder, um reine Textblöcke zu schaffen!</td>
+                                            </tr>
+                                        </table>
+                                    </td>
+
+                                    <td align="center" class="templateColumnContainer" style="padding-top: 20px; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 200px;" valign="top">
+                                        <table border="0" cellpadding="20" cellspacing="0" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;" width="100%">
+                                            <tr>
+                                                <td pardot-region="right_column_image" align="left" class="rightColumnContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 14px; line-height: 21px; text-align: left; padding: 0 20px 20px;"><img class="columnImage" src="/images/placeholder.php?width=160&amp;height=120" style="max-width: 160px; -ms-interpolation-mode: bicubic; height: auto; outline: none; text-decoration: none; display: inline; border: 0;" alt="" /></td>
+                                            </tr>
+
+                                            <tr>
+                                                <td pardot-region="right_column_content" align="left" class="rightColumnContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 14px; line-height: 21px; text-align: left; padding: 0 20px 20px;" valign="top">
+                                                    <h3 style="color: #606060 !important; display: block; font-family: Helvetica; font-size: 16px; font-style: italic; font-weight: normal; letter-spacing: normal; line-height: 16px; margin: 0; padding-bottom:10px; text-align: left">Wiederholbarer Inhalt</h3><strong>Wiederholbare Inhaltsblöcke:</strong> Bewegen Sie den Mauszeiger über den Dropdown-Pfeil in der oberen rechten Ecke eines Bereichs, um ein Menü mit dafür spezifischen Optionen wie &apos;Kopieren&apos;, &apos;Zeile nach oben verschieben&apos; oder &apos;Löschen&apos; einzublenden. Sie können auch <a href="#" style="color: #336699; font-weight: normal; text-decoration: underline; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%;" target="_blank">etwas von der Norm abweichen</a>: Verwenden Sie Blöcke wiederholt und entfernen Sie den gesamten Text, um &apos;Galerie&apos;-Abschnitte mit Bildern zu erstellen, oder tun Sie das Gegenteil und entfernen Sie Bilder, um reine Textblöcke zu schaffen!</td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </table><!-- // END COLUMNS --></td>
+                    </tr>
+
+                    <tr>
+                        <td align="center" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt;" valign="top"><!-- BEGIN FOOTER // --><table border="0" cellpadding="0" cellspacing="0" id="templateFooter" style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #FFFFFF; border-collapse: collapse !important; border-top-color: #FFFFFF; border-top-style: solid; border-top-width: 1px; mso-table-lspace: 0pt; mso-table-rspace: 0pt" width="100%">
+                                <tr pardot-removable="">
+                                    <td pardot-region="footer_content00" align="left" class="footerContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #808080; font-family: Helvetica; font-size: 10px; line-height: 15px; text-align: left; padding: 20px;" valign="top"><a href="#" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #606060; font-weight: normal; text-decoration: underline;">Auf Twitter folgen</a>&nbsp;&nbsp;&nbsp;<a href="#" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #606060; font-weight: normal; text-decoration: underline;">Freund in Facebook</a>&nbsp;&nbsp;&nbsp;<a href="{{addthis_url_email}}" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #606060; font-weight: normal; text-decoration: underline;">Weiterleiten an einen Freund</a>&nbsp;</td>
+                                </tr>
+
+                                <tr>
+                                    <td pardot-region="footer_content01" align="left" class="footerContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #808080; font-family: Helvetica; font-size: 10px; line-height: 15px; text-align: left; padding: 0 20px 20px;" valign="top"><em>Copyright © {{Current_Year}}. Alle Rechte vorbehalten.</em><br /> <br /> <strong>Unsere Postanschrift lautet:</strong><br /> {{{Organization.Address}}}</td>
+                                </tr>
+
+                                <tr>
+                                    <td pardot-region="footer_content02" align="left" class="footerContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #808080; font-family: Helvetica; font-size: 10px; line-height: 15px; text-align: left; padding: 0 20px 20px;" valign="top"><a href="{{Unsubscribe}}" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #606060; font-weight: normal; text-decoration: underline;">Abonnement aller E-Mails beenden</a>&nbsp;&nbsp;&nbsp;<a href="{{{EmailPreferenceCenter}}}" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #606060; font-weight: normal; text-decoration: underline;">Abonnementeinstellungen aktualisieren</a>&nbsp;</td>
+                                </tr>
+                            </table><!-- // END FOOTER --></td>
+                    </tr>
+                </table><!-- // END TEMPLATE --></td>
+        </tr>
+    </table><br /> <!--
+          This email was originally designed by the wonderful folks at MailChimp and remixed by Pardot.
+          It is licensed under CC BY-SA 3.0
+        --></body>
+</html>

--- a/HML/en_US/Responsive 3 Column (5333).html
+++ b/HML/en_US/Responsive 3 Column (5333).html
@@ -1,0 +1,278 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
+
+    <!-- Facebook sharing information tags -->
+	<meta property="og:title" content="{{Subject}}" />
+
+    <title>{{Subject}}</title>
+</head>
+
+<body bgcolor="#FAFAFA" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; height: 100% !important; width: 100% !important; background-color: #FAFAFA; margin: 0; padding: 0;">
+    <style type="text/css">
+      #outlook a {
+          padding: 0;
+      }
+      .body{
+          width: 100% !important;
+          -webkit-text-size-adjust: 100%;
+          -ms-text-size-adjust: 100%;
+          margin: 0;
+          padding: 0;
+      }
+      .ExternalClass {
+          width:100%;
+      }
+      .ExternalClass,
+      .ExternalClass p,
+      .ExternalClass span,
+      .ExternalClass font,
+      .ExternalClass td,
+      .ExternalClass div {
+          line-height: 100%;
+      }
+      img {
+          outline: none;
+          text-decoration: none;
+          -ms-interpolation-mode: bicubic;
+      }
+      a img {
+          border: none;
+      }
+      p {
+          margin: 1em 0;
+      }
+      table td {
+          border-collapse: collapse;
+      }
+      /* hide unsubscribe from forwards*/
+      blockquote .original-only, .WordSection1 .original-only {
+        display: none !important;
+      }
+
+      @media only screen and (max-width: 480px){
+        body, table, td, p, a, li, blockquote{-webkit-text-size-adjust:none !important;} /* Prevent Webkit platforms from changing default text sizes */
+                body{width:100% !important; min-width:100% !important;} /* Prevent iOS Mail from adding padding to the body */
+
+        #bodyCell{padding:10px !important;}
+
+        #templateContainer{
+          max-width:600px !important;
+          width:100% !important;
+        }
+
+        h1{
+          font-size:24px !important;
+          line-height:100% !important;
+        }
+
+        h2{
+          font-size:20px !important;
+          line-height:100% !important;
+        }
+
+        h3{
+          font-size:18px !important;
+          line-height:100% !important;
+        }
+
+        h4{
+          font-size:16px !important;
+          line-height:100% !important;
+        }
+
+        #templatePreheader{display:none !important;} /* Hide the template preheader to save space */
+
+        #headerImage{
+          height:auto !important;
+          max-width:600px !important;
+          width:100% !important;
+        }
+
+        .headerContent{
+          font-size:20px !important;
+          line-height:125% !important;
+        }
+
+        .bodyContent{
+          font-size:18px !important;
+          line-height:125% !important;
+        }
+
+        .templateColumnContainer{display:block !important; width:100% !important;}
+
+        .columnImage{
+          height:auto !important;
+          max-width:480px !important;
+          width:100% !important;
+        }
+
+        .leftColumnContent{
+          font-size:16px !important;
+          line-height:125% !important;
+        }
+
+        .centerColumnContent{
+          font-size:16px !important;
+          line-height:125% !important;
+        }
+
+        .rightColumnContent{
+          font-size:16px !important;
+          line-height:125% !important;
+        }
+
+        .footerContent{
+          font-size:14px !important;
+          line-height:115% !important;
+        }
+
+        .footerContent a{display:block !important;} /* Place footer social and utility links on their own lines, for easier access */
+      }
+    </style>
+
+    <table align="center" border="0" cellpadding="0" cellspacing="0" id="bodyTable" style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #FAFAFA; border-collapse: collapse !important; height: 100% !important; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding: 0; width: 100% !important" width="100%">
+        <tr>
+            <td align="center" id="bodyCell" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; height: 100% !important; width: 100% !important; border-top-width: 4px; border-top-color: #dddddd; border-top-style: solid; margin: 0; padding: 20px;" valign="top">
+                <!-- BEGIN TEMPLATE // -->
+                <table border="0" cellpadding="0" cellspacing="0" id="templateContainer" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important; width: 600px; border: 1px solid #dddddd;">
+                    <tr>
+                        <td align="center" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt;" valign="top">
+                            <!-- BEGIN PREHEADER // -->
+                            <table border="0" cellpadding="0" cellspacing="0" id="templatePreheader" style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #FFFFFF; border-bottom-color: #CCCCCC; border-bottom-style: solid; border-bottom-width: 1px; border-collapse: collapse !important; mso-table-lspace: 0pt; mso-table-rspace: 0pt" width="100%">
+                                <tr>
+                                    <td pardot-region="preheader_content00" align="left" class="preheaderContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #808080; font-family: Helvetica; font-size: 10px; line-height: 12.5px; text-align: left; padding: 10px 20px;" valign="top">Use this area to offer a short teaser of your email's content. Text here will show in the preview area of some email clients.</td>
+
+                                    <td pardot-region="preheader_content01" align="left" class="preheaderContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #808080; font-family: Helvetica; font-size: 10px; line-height: 12.5px; text-align: left; padding: 10px 20px 10px 0;" valign="top" width="180">
+                                        Email not displaying correctly?<br />
+                                        <a href="{{View_Online}}" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #606060; font-weight: normal; text-decoration: underline;" target="_blank">View it in your browser</a>.
+                                    </td>
+                                </tr>
+                            </table>
+                            <!-- // END PREHEADER -->
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td align="center" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt;" valign="top">
+                            <!-- BEGIN HEADER // -->
+                            <table border="0" cellpadding="0" cellspacing="0" id="templateHeader" style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #FFFFFF; border-bottom-color: #CCCCCC; border-bottom-style: solid; border-bottom-width: 1px; border-collapse: collapse !important; mso-table-lspace: 0pt; mso-table-rspace: 0pt" width="100%">
+                                <tr pardot-repeatable="">
+                                    <td pardot-region="header_image" align="left" class="headerContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 20px; font-weight: bold; line-height: 20px; text-align: left; vertical-align: middle; padding: 0;" valign="top"><img id="headerImage" src="/images/placeholder.php?width=600&amp;height=150" style="max-width: 600px; -ms-interpolation-mode: bicubic; height: auto; outline: none; text-decoration: none; border: 0;" alt="" /></td>
+                                </tr>
+                            </table>
+                            <!-- // END HEADER -->
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td align="center" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt;" valign="top">
+                            <!-- BEGIN BODY // -->
+                            <table border="0" cellpadding="0" cellspacing="0" id="templateBody" style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #FFFFFF; border-bottom-color: #CCCCCC; border-bottom-style: solid; border-bottom-width: 1px; border-collapse: collapse !important; border-top-color: #FFFFFF; border-top-style: solid; border-top-width: 1px; mso-table-lspace: 0pt; mso-table-rspace: 0pt" width="100%">
+                                <tr pardot-repeatable="">
+                                    <td pardot-region="body_content" align="left" class="bodyContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 16px; line-height: 24px; text-align: left; padding: 20px;" valign="top">
+                                        <h1 style="color: #202020 !important; display: block; font-family: Helvetica; font-size: 26px; font-style: normal; font-weight: bold; letter-spacing: normal; line-height: 26px; margin: 0; padding-bottom:10px; text-align: left">Designing Your Template</h1>
+
+                                        <h3 style="color: #606060 !important; display: block; font-family: Helvetica; font-size: 16px; font-style: italic; font-weight: normal; letter-spacing: normal; line-height: 16px; margin: 0; padding-bottom:10px; text-align: left">Creating a good-looking email is simple</h3>Customize your template by clicking on the style editor tabs on your right. Set your fonts, colors, and styles. After setting your styling is all done you can click here in this area, delete the text, and start adding your own awesome content.<br />
+                                        <br />
+
+                                        <h2 style="color: #404040 !important; display: block; font-family: Helvetica; font-size: 20px; font-style: normal; font-weight: bold; letter-spacing: normal; line-height: 20px; margin: 0; padding-bottom:10px; text-align: left">Styling Your Content</h2>
+
+                                        <h4 style="color: #808080 !important; display: block; font-family: Helvetica; font-size: 14px; font-style: italic; font-weight: normal; letter-spacing: normal; line-height: 14px; margin: 0; padding-bottom:10px; text-align: left">Make your email easy to read</h4>After you enter your content, highlight the text you want to style and select the options you set in the style editor in the "<em>styles</em>" tab. Want to <a href="#" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #336699; font-weight: normal; text-decoration: underline;">get rid of styling on a bit of text</a>, but having trouble doing it? Just use the "<em>remove formatting</em>" button to strip the text of any formatting and reset your style.
+                                    </td>
+                                </tr>
+                            </table>
+                            <!-- // END BODY -->
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td align="center" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt;" valign="top">
+                            <!-- BEGIN COLUMNS // -->
+                            <table border="0" cellpadding="0" cellspacing="0" id="templateColumns" style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #FFFFFF; border-bottom-color: #CCCCCC; border-bottom-style: solid; border-bottom-width: 1px; border-collapse: collapse !important; border-top-color: #FFFFFF; border-top-style: solid; border-top-width: 1px; mso-table-lspace: 0pt; mso-table-rspace: 0pt" width="100%">
+                                <tr pardot-repeatable="">
+                                    <td align="center" class="templateColumnContainer" style="padding-top: 20px; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 200px;" valign="top">
+                                        <table border="0" cellpadding="20" cellspacing="0" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;" width="100%">
+                                            <tr>
+                                                <td pardot-region="left_content_image" align="left" class="leftColumnContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 14px; line-height: 21px; text-align: left; padding: 0 20px 20px;"><img class="columnImage" src="/images/placeholder.php?width=160&amp;height=120" style="max-width: 160px; -ms-interpolation-mode: bicubic; height: auto; outline: none; text-decoration: none; display: inline; border: 0;" alt="" /></td>
+                                            </tr>
+
+                                            <tr>
+                                                <td pardot-region="left_column_content" align="left" class="leftColumnContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 14px; line-height: 21px; text-align: left; padding: 0 20px 20px;" valign="top">
+                                                    <h3 style="color: #606060 !important; display: block; font-family: Helvetica; font-size: 16px; font-style: italic; font-weight: normal; letter-spacing: normal; line-height: 16px; margin: 0; padding-bottom:10px; text-align: left">Repeatable Content</h3><strong>Repeatable content blocks:</strong> Hover over the drop arrow in the upper right of a region to toggle a menu of options unique to that section, like 'Copy', 'Move Row Up', or 'Delete'. You can also <a href="#" style="color: #336699; font-weight: normal; text-decoration: underline; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%;" target="_blank">get a little fancy</a>: repeat blocks and remove all text to make image "gallery" sections, or do the opposite and remove images for text-only blocks!
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
+
+                                    <td align="center" class="templateColumnContainer" style="padding-top: 20px; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 200px;" valign="top">
+                                        <table border="0" cellpadding="20" cellspacing="0" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;" width="100%">
+                                            <tr>
+                                                <td pardot-region="center_column_image" align="left" class="centerColumnContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 14px; line-height: 21px; text-align: left; padding: 0 20px 20px;"><img class="columnImage" src="/images/placeholder.php?width=160&amp;height=120" style="max-width: 160px; -ms-interpolation-mode: bicubic; height: auto; outline: none; text-decoration: none; border: 0;" alt="" /></td>
+                                            </tr>
+
+                                            <tr>
+                                                <td pardot-region="center_column_content" align="left" class="centerColumnContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 14px; line-height: 21px; text-align: left; padding: 0 20px 20px;" valign="top">
+                                                    <h3 style="color: #606060 !important; display: block; font-family: Helvetica; font-size: 16px; font-style: italic; font-weight: normal; letter-spacing: normal; line-height: 16px; margin: 0; padding-bottom:10px; text-align: left">Repeatable Content</h3><strong>Repeatable content blocks:</strong> Hover over the drop arrow in the upper right of a region to toggle a menu of options unique to that section, like 'Copy', 'Move Row Up', or 'Delete'. You can also <a href="#" style="color: #336699; font-weight: normal; text-decoration: underline; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%;" target="_blank">get a little fancy</a>: repeat blocks and remove all text to make image "gallery" sections, or do the opposite and remove images for text-only blocks!
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
+
+                                    <td align="center" class="templateColumnContainer" style="padding-top: 20px; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 200px;" valign="top">
+                                        <table border="0" cellpadding="20" cellspacing="0" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;" width="100%">
+                                            <tr>
+                                                <td pardot-region="right_column_image" align="left" class="rightColumnContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 14px; line-height: 21px; text-align: left; padding: 0 20px 20px;"><img class="columnImage" src="/images/placeholder.php?width=160&amp;height=120" style="max-width: 160px; -ms-interpolation-mode: bicubic; height: auto; outline: none; text-decoration: none; display: inline; border: 0;" alt="" /></td>
+                                            </tr>
+
+                                            <tr>
+                                                <td pardot-region="right_column_content" align="left" class="rightColumnContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 14px; line-height: 21px; text-align: left; padding: 0 20px 20px;" valign="top">
+                                                    <h3 style="color: #606060 !important; display: block; font-family: Helvetica; font-size: 16px; font-style: italic; font-weight: normal; letter-spacing: normal; line-height: 16px; margin: 0; padding-bottom:10px; text-align: left">Repeatable Content</h3><strong>Repeatable content blocks:</strong> Hover over the drop arrow in the upper right of a region to toggle a menu of options unique to that section, like 'Copy', 'Move Row Up', or 'Delete'. You can also <a href="#" style="color: #336699; font-weight: normal; text-decoration: underline; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%;" target="_blank">get a little fancy</a>: repeat blocks and remove all text to make image "gallery" sections, or do the opposite and remove images for text-only blocks!
+                                                </td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </table>
+                            <!-- // END COLUMNS -->
+                        </td>
+                    </tr>
+
+                    <tr>
+                        <td align="center" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt;" valign="top">
+                            <!-- BEGIN FOOTER // -->
+                            <table border="0" cellpadding="0" cellspacing="0" id="templateFooter" style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #FFFFFF; border-collapse: collapse !important; border-top-color: #FFFFFF; border-top-style: solid; border-top-width: 1px; mso-table-lspace: 0pt; mso-table-rspace: 0pt" width="100%">
+                                <tr pardot-removable="">
+                                    <td pardot-region="footer_content00" align="left" class="footerContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #808080; font-family: Helvetica; font-size: 10px; line-height: 15px; text-align: left; padding: 20px;" valign="top">
+                                        <a href="#" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #606060; font-weight: normal; text-decoration: underline;">Follow on Twitter</a>&nbsp;&nbsp;&nbsp;<a href="#" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #606060; font-weight: normal; text-decoration: underline;">Friend on Facebook</a>&nbsp;&nbsp;&nbsp;<a href="{{addthis_url_email}}" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #606060; font-weight: normal; text-decoration: underline;">Forward to Friend</a>&nbsp;
+                                    </td>
+                                </tr>
+
+                                <tr>
+                                    <td pardot-region="footer_content01" align="left" class="footerContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #808080; font-family: Helvetica; font-size: 10px; line-height: 15px; text-align: left; padding: 0 20px 20px;" valign="top"><em>Copyright © {{Current_Year}}, All rights reserved.</em><br />
+                                    <br />
+                                    <strong>Our mailing address is:</strong><br />
+                                    {{{Organization.Address}}}</td>
+                                </tr>
+
+                                <tr>
+                                    <td pardot-region="footer_content02" align="left" class="footerContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #808080; font-family: Helvetica; font-size: 10px; line-height: 15px; text-align: left; padding: 0 20px 20px;" valign="top">
+                                        <a href="{{Unsubscribe}}" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #606060; font-weight: normal; text-decoration: underline;">unsubscribe from all emails</a>&nbsp;&nbsp;&nbsp;<a href="{{{EmailPreferenceCenter}}}" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #606060; font-weight: normal; text-decoration: underline;">update subscription preferences</a>&nbsp;
+                                    </td>
+                                </tr>
+                            </table>
+                            <!-- // END FOOTER -->
+                        </td>
+                    </tr>
+                </table>
+                <!-- // END TEMPLATE -->
+            </td>
+        </tr>
+    </table><br />
+    <!--
+          This email was originally designed by the wonderful folks at MailChimp and remixed by Pardot.
+          It is licensed under CC BY-SA 3.0
+        -->
+</body>
+</html>

--- a/HML/es_ES/3 columnas reactiva (5303).html
+++ b/HML/es_ES/3 columnas reactiva (5303).html
@@ -1,0 +1,232 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="UTF-8"><!-- Facebook sharing information tags --><meta property="og:title" content="{{Subject}}" />
+
+    <title>{{Subject}}</title>
+</head>
+
+<body bgcolor="#FAFAFA" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; height: 100% !important; width: 100% !important; background-color: #FAFAFA; margin: 0; padding: 0;">
+    <style type="text/css">
+      #outlook a {
+          padding: 0;
+      }
+      .body{
+          width: 100% !important;
+          -webkit-text-size-adjust: 100%;
+          -ms-text-size-adjust: 100%;
+          margin: 0;
+          padding: 0;
+      }
+      .ExternalClass {
+          width:100%;
+      }
+      .ExternalClass,
+      .ExternalClass p,
+      .ExternalClass span,
+      .ExternalClass font,
+      .ExternalClass td,
+      .ExternalClass div {
+          line-height: 100%;
+      }
+      img {
+          outline: none;
+          text-decoration: none;
+          -ms-interpolation-mode: bicubic;
+      }
+      a img {
+          border: none;
+      }
+      p {
+          margin: 1em 0;
+      }
+      table td {
+          border-collapse: collapse;
+      }
+      /* hide unsubscribe from forwards*/
+      blockquote .original-only, .WordSection1 .original-only {
+        display: none !important;
+      }
+
+      @media only screen and (max-width: 480px){
+        body, table, td, p, a, li, blockquote{-webkit-text-size-adjust:none !important;} /* Prevent Webkit platforms from changing default text sizes */
+                body{width:100% !important; min-width:100% !important;} /* Prevent iOS Mail from adding padding to the body */
+
+        #bodyCell{padding:10px !important;}
+
+        #templateContainer{
+          max-width:600px !important;
+          width:100% !important;
+        }
+
+        h1{
+          font-size:24px !important;
+          line-height:100% !important;
+        }
+
+        h2{
+          font-size:20px !important;
+          line-height:100% !important;
+        }
+
+        h3{
+          font-size:18px !important;
+          line-height:100% !important;
+        }
+
+        h4{
+          font-size:16px !important;
+          line-height:100% !important;
+        }
+
+        #templatePreheader{display:none !important;} /* Hide the template preheader to save space */
+
+        #headerImage{
+          height:auto !important;
+          max-width:600px !important;
+          width:100% !important;
+        }
+
+        .headerContent{
+          font-size:20px !important;
+          line-height:125% !important;
+        }
+
+        .bodyContent{
+          font-size:18px !important;
+          line-height:125% !important;
+        }
+
+        .templateColumnContainer{display:block !important; width:100% !important;}
+
+        .columnImage{
+          height:auto !important;
+          max-width:480px !important;
+          width:100% !important;
+        }
+
+        .leftColumnContent{
+          font-size:16px !important;
+          line-height:125% !important;
+        }
+
+        .centerColumnContent{
+          font-size:16px !important;
+          line-height:125% !important;
+        }
+
+        .rightColumnContent{
+          font-size:16px !important;
+          line-height:125% !important;
+        }
+
+        .footerContent{
+          font-size:14px !important;
+          line-height:115% !important;
+        }
+
+        .footerContent a{display:block !important;} /* Place footer social and utility links on their own lines, for easier access */
+      }
+    </style>
+
+    <table align="center" border="0" cellpadding="0" cellspacing="0" id="bodyTable" style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #FAFAFA; border-collapse: collapse !important; height: 100% !important; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding: 0; width: 100% !important" width="100%">
+        <tr>
+            <td align="center" id="bodyCell" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; height: 100% !important; width: 100% !important; border-top-width: 4px; border-top-color: #dddddd; border-top-style: solid; margin: 0; padding: 20px;" valign="top"><!-- BEGIN TEMPLATE // --><table border="0" cellpadding="0" cellspacing="0" id="templateContainer" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important; width: 600px; border: 1px solid #dddddd;">
+                    <tr>
+                        <td align="center" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt;" valign="top"><!-- BEGIN PREHEADER // --><table border="0" cellpadding="0" cellspacing="0" id="templatePreheader" style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #FFFFFF; border-bottom-color: #CCCCCC; border-bottom-style: solid; border-bottom-width: 1px; border-collapse: collapse !important; mso-table-lspace: 0pt; mso-table-rspace: 0pt" width="100%">
+                                <tr>
+                                    <td pardot-region="preheader_content00" align="left" class="preheaderContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #808080; font-family: Helvetica; font-size: 10px; line-height: 12.5px; text-align: left; padding: 10px 20px;" valign="top">Utilice este área para ofrecer un breve adelanto del contenido de su mensaje. El texto que hay aquí se mostrará en el área de vista previa de algunos clientes de correo.</td>
+
+                                    <td pardot-region="preheader_content01" align="left" class="preheaderContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #808080; font-family: Helvetica; font-size: 10px; line-height: 12.5px; text-align: left; padding: 10px 20px 10px 0;" valign="top" width="180">¿No se muestra bien el mensaje de correo electrónico?<br /> <a href="{{View_Online}}" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #606060; font-weight: normal; text-decoration: underline;" target="_blank">Véalo en su navegador</a>.</td>
+                                </tr>
+                            </table><!-- // END PREHEADER --></td>
+                    </tr>
+
+                    <tr>
+                        <td align="center" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt;" valign="top"><!-- BEGIN HEADER // --><table border="0" cellpadding="0" cellspacing="0" id="templateHeader" style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #FFFFFF; border-bottom-color: #CCCCCC; border-bottom-style: solid; border-bottom-width: 1px; border-collapse: collapse !important; mso-table-lspace: 0pt; mso-table-rspace: 0pt" width="100%">
+                                <tr pardot-repeatable="">
+                                    <td pardot-region="header_image" align="left" class="headerContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 20px; font-weight: bold; line-height: 20px; text-align: left; vertical-align: middle; padding: 0;" valign="top"><img id="headerImage" src="/images/placeholder.php?width=600&amp;height=150" style="max-width: 600px; -ms-interpolation-mode: bicubic; height: auto; outline: none; text-decoration: none; border: 0;" alt="" /></td>
+                                </tr>
+                            </table><!-- // END HEADER --></td>
+                    </tr>
+
+                    <tr>
+                        <td align="center" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt;" valign="top"><!-- BEGIN BODY // --><table border="0" cellpadding="0" cellspacing="0" id="templateBody" style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #FFFFFF; border-bottom-color: #CCCCCC; border-bottom-style: solid; border-bottom-width: 1px; border-collapse: collapse !important; border-top-color: #FFFFFF; border-top-style: solid; border-top-width: 1px; mso-table-lspace: 0pt; mso-table-rspace: 0pt" width="100%">
+                                <tr pardot-repeatable="">
+                                    <td pardot-region="body_content" align="left" class="bodyContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 16px; line-height: 24px; text-align: left; padding: 20px;" valign="top">
+                                        <h1 style="color: #202020 !important; display: block; font-family: Helvetica; font-size: 26px; font-style: normal; font-weight: bold; letter-spacing: normal; line-height: 26px; margin: 0; padding-bottom:10px; text-align: left">Diseño de su plantilla</h1>
+
+                                        <h3 style="color: #606060 !important; display: block; font-family: Helvetica; font-size: 16px; font-style: italic; font-weight: normal; letter-spacing: normal; line-height: 16px; margin: 0; padding-bottom:10px; text-align: left">La creación de una plantilla con un buen aspecto es sencillo</h3>Personalice su plantilla haciendo clic en las fichas del editor de estilos a su derecha. Establezca sus tipos de letra, colores y estilos. Después de terminar con el estilo, puede hacer clic aquí en este área, eliminar el texto y empezar a incorporar su propio contenido excelente.<br /> <br /><h2 style="color: #404040 !important; display: block; font-family: Helvetica; font-size: 20px; font-style: normal; font-weight: bold; letter-spacing: normal; line-height: 20px; margin: 0; padding-bottom:10px; text-align: left">Aplicar estilo a su contenido</h2>
+
+                                        <h4 style="color: #808080 !important; display: block; font-family: Helvetica; font-size: 14px; font-style: italic; font-weight: normal; letter-spacing: normal; line-height: 14px; margin: 0; padding-bottom:10px; text-align: left">Haga que su mensaje sea fácil de leer</h4>Después de introducir su contenido, resalte el texto al que quiere asignar el estilo y seleccione las opciones que estableció en el editor de estilos en la ficha &quot;<em>estilos</em>&quot;. ¿Desea <a href="#" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #336699; font-weight: normal; text-decoration: underline;">quitar estilos de una parte del texto</a> pero tiene problemas para hacerlo? Solo tiene que utilizar el botón &quot;<em>retirar formato</em>&quot; para quitar el formato a cualquier parte del texto y restablecer su estilo.</td>
+                                </tr>
+                            </table><!-- // END BODY --></td>
+                    </tr>
+
+                    <tr>
+                        <td align="center" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt;" valign="top"><!-- BEGIN COLUMNS // --><table border="0" cellpadding="0" cellspacing="0" id="templateColumns" style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #FFFFFF; border-bottom-color: #CCCCCC; border-bottom-style: solid; border-bottom-width: 1px; border-collapse: collapse !important; border-top-color: #FFFFFF; border-top-style: solid; border-top-width: 1px; mso-table-lspace: 0pt; mso-table-rspace: 0pt" width="100%">
+                                <tr pardot-repeatable="">
+                                    <td align="center" class="templateColumnContainer" style="padding-top: 20px; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 200px;" valign="top">
+                                        <table border="0" cellpadding="20" cellspacing="0" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;" width="100%">
+                                            <tr>
+                                                <td pardot-region="left_content_image" align="left" class="leftColumnContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 14px; line-height: 21px; text-align: left; padding: 0 20px 20px;"><img class="columnImage" src="/images/placeholder.php?width=160&amp;height=120" style="max-width: 160px; -ms-interpolation-mode: bicubic; height: auto; outline: none; text-decoration: none; display: inline; border: 0;" alt="" /></td>
+                                            </tr>
+
+                                            <tr>
+                                                <td pardot-region="left_column_content" align="left" class="leftColumnContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 14px; line-height: 21px; text-align: left; padding: 0 20px 20px;" valign="top">
+                                                    <h3 style="color: #606060 !important; display: block; font-family: Helvetica; font-size: 16px; font-style: italic; font-weight: normal; letter-spacing: normal; line-height: 16px; margin: 0; padding-bottom:10px; text-align: left">Contenido repetible</h3><strong>Bloques de contenido repetibles:</strong> Pase el ratón sobre la flecha para soltar en la esquina superior derecha de una zona para que aparezca un menú de opciones exclusivo de esa sección, como &quot;Copiar&quot;, &quot;Mover fila hacia arriba&quot; o &quot;Eliminar&quot;. También puede <a href="#" style="color: #336699; font-weight: normal; text-decoration: underline; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%;" target="_blank">ponerse creativo</a>: repita bloques y retire todo el texto para hacer secciones de &quot;galería&quot; de imágenes, o haga justo lo contrario y elimine imágenes para conseguir bloques con texto únicamente.</td>
+                                            </tr>
+                                        </table>
+                                    </td>
+
+                                    <td align="center" class="templateColumnContainer" style="padding-top: 20px; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 200px;" valign="top">
+                                        <table border="0" cellpadding="20" cellspacing="0" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;" width="100%">
+                                            <tr>
+                                                <td pardot-region="center_column_image" align="left" class="centerColumnContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 14px; line-height: 21px; text-align: left; padding: 0 20px 20px;"><img class="columnImage" src="/images/placeholder.php?width=160&amp;height=120" style="max-width: 160px; -ms-interpolation-mode: bicubic; height: auto; outline: none; text-decoration: none; border: 0;" alt="" /></td>
+                                            </tr>
+
+                                            <tr>
+                                                <td pardot-region="center_column_content" align="left" class="centerColumnContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 14px; line-height: 21px; text-align: left; padding: 0 20px 20px;" valign="top">
+                                                    <h3 style="color: #606060 !important; display: block; font-family: Helvetica; font-size: 16px; font-style: italic; font-weight: normal; letter-spacing: normal; line-height: 16px; margin: 0; padding-bottom:10px; text-align: left">Contenido repetible</h3><strong>Bloques de contenido repetibles:</strong> Pase el ratón sobre la flecha para soltar en la esquina superior derecha de una zona para que aparezca un menú de opciones exclusivo de esa sección, como &quot;Copiar&quot;, &quot;Mover fila hacia arriba&quot; o &quot;Eliminar&quot;. También puede <a href="#" style="color: #336699; font-weight: normal; text-decoration: underline; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%;" target="_blank">ponerse creativo</a>: repita bloques y retire todo el texto para hacer secciones de &quot;galería&quot; de imágenes, o haga justo lo contrario y elimine imágenes para conseguir bloques con texto únicamente.</td>
+                                            </tr>
+                                        </table>
+                                    </td>
+
+                                    <td align="center" class="templateColumnContainer" style="padding-top: 20px; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 200px;" valign="top">
+                                        <table border="0" cellpadding="20" cellspacing="0" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;" width="100%">
+                                            <tr>
+                                                <td pardot-region="right_column_image" align="left" class="rightColumnContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 14px; line-height: 21px; text-align: left; padding: 0 20px 20px;"><img class="columnImage" src="/images/placeholder.php?width=160&amp;height=120" style="max-width: 160px; -ms-interpolation-mode: bicubic; height: auto; outline: none; text-decoration: none; display: inline; border: 0;" alt="" /></td>
+                                            </tr>
+
+                                            <tr>
+                                                <td pardot-region="right_column_content" align="left" class="rightColumnContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 14px; line-height: 21px; text-align: left; padding: 0 20px 20px;" valign="top">
+                                                    <h3 style="color: #606060 !important; display: block; font-family: Helvetica; font-size: 16px; font-style: italic; font-weight: normal; letter-spacing: normal; line-height: 16px; margin: 0; padding-bottom:10px; text-align: left">Contenido repetible</h3><strong>Bloques de contenido repetibles:</strong> Pase el ratón sobre la flecha para soltar en la esquina superior derecha de una zona para que aparezca un menú de opciones exclusivo de esa sección, como &quot;Copiar&quot;, &quot;Mover fila hacia arriba&quot; o &quot;Eliminar&quot;. También puede <a href="#" style="color: #336699; font-weight: normal; text-decoration: underline; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%;" target="_blank">ponerse creativo</a>: repita bloques y retire todo el texto para hacer secciones de &quot;galería&quot; de imágenes, o haga justo lo contrario y elimine imágenes para conseguir bloques con texto únicamente.</td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </table><!-- // END COLUMNS --></td>
+                    </tr>
+
+                    <tr>
+                        <td align="center" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt;" valign="top"><!-- BEGIN FOOTER // --><table border="0" cellpadding="0" cellspacing="0" id="templateFooter" style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #FFFFFF; border-collapse: collapse !important; border-top-color: #FFFFFF; border-top-style: solid; border-top-width: 1px; mso-table-lspace: 0pt; mso-table-rspace: 0pt" width="100%">
+                                <tr pardot-removable="">
+                                    <td pardot-region="footer_content00" align="left" class="footerContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #808080; font-family: Helvetica; font-size: 10px; line-height: 15px; text-align: left; padding: 20px;" valign="top"><a href="#" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #606060; font-weight: normal; text-decoration: underline;">Seguir en Twitter</a> &nbsp;&nbsp;&nbsp; <a href="#" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #606060; font-weight: normal; text-decoration: underline;">Amigo en Facebook</a> &nbsp;&nbsp;&nbsp; <a href="{{addthis_url_email}}" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #606060; font-weight: normal; text-decoration: underline;">Reenviar a un amigo</a>&nbsp;</td>
+                                </tr>
+
+                                <tr>
+                                    <td pardot-region="footer_content01" align="left" class="footerContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #808080; font-family: Helvetica; font-size: 10px; line-height: 15px; text-align: left; padding: 0 20px 20px;" valign="top"><em>Copyright © {{Current_Year}}, Todos los derechos reservados.</em><br /> <br /> <strong>Nuestra dirección de correo es:</strong><br /> {{{Organization.Address}}}</td>
+                                </tr>
+
+                                <tr>
+                                    <td pardot-region="footer_content02" align="left" class="footerContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #808080; font-family: Helvetica; font-size: 10px; line-height: 15px; text-align: left; padding: 0 20px 20px;" valign="top"><a href="{{Unsubscribe}}" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #606060; font-weight: normal; text-decoration: underline;">cancelar la suscripción a todos los correos</a> &nbsp;&nbsp;&nbsp; <a href="{{{EmailPreferenceCenter}}}" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #606060; font-weight: normal; text-decoration: underline;">actualizar preferencias de suscripción</a>&nbsp;</td>
+                                </tr>
+                            </table><!-- // END FOOTER --></td>
+                    </tr>
+                </table><!-- // END TEMPLATE --></td>
+        </tr>
+    </table><br /> <!--
+          This email was originally designed by the wonderful folks at MailChimp and remixed by Pardot.
+          It is licensed under CC BY-SA 3.0
+        --></body>
+</html>

--- a/HML/ja_JP/反応型 3 列 (5343).html
+++ b/HML/ja_JP/反応型 3 列 (5343).html
@@ -1,0 +1,232 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type" /><!-- Facebook sharing information tags --><meta property="og:title" content="{{Subject}}" />
+
+    <title>{{Subject}}</title>
+</head>
+
+<body bgcolor="#FAFAFA" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; height: 100% !important; width: 100% !important; background-color: #FAFAFA; margin: 0; padding: 0;">
+    <style type="text/css">
+      #outlook a {
+          padding: 0;
+      }
+      .body{
+          width: 100% !important;
+          -webkit-text-size-adjust: 100%;
+          -ms-text-size-adjust: 100%;
+          margin: 0;
+          padding: 0;
+      }
+      .ExternalClass {
+          width:100%;
+      }
+      .ExternalClass,
+      .ExternalClass p,
+      .ExternalClass span,
+      .ExternalClass font,
+      .ExternalClass td,
+      .ExternalClass div {
+          line-height: 100%;
+      }
+      img {
+          outline: none;
+          text-decoration: none;
+          -ms-interpolation-mode: bicubic;
+      }
+      a img {
+          border: none;
+      }
+      p {
+          margin: 1em 0;
+      }
+      table td {
+          border-collapse: collapse;
+      }
+      /* hide unsubscribe from forwards*/
+      blockquote .original-only, .WordSection1 .original-only {
+        display: none !important;
+      }
+
+      @media only screen and (max-width: 480px){
+        body, table, td, p, a, li, blockquote{-webkit-text-size-adjust:none !important;} /* Prevent Webkit platforms from changing default text sizes */
+                body{width:100% !important; min-width:100% !important;} /* Prevent iOS Mail from adding padding to the body */
+
+        #bodyCell{padding:10px !important;}
+
+        #templateContainer{
+          max-width:600px !important;
+          width:100% !important;
+        }
+
+        h1{
+          font-size:24px !important;
+          line-height:100% !important;
+        }
+
+        h2{
+          font-size:20px !important;
+          line-height:100% !important;
+        }
+
+        h3{
+          font-size:18px !important;
+          line-height:100% !important;
+        }
+
+        h4{
+          font-size:16px !important;
+          line-height:100% !important;
+        }
+
+        #templatePreheader{display:none !important;} /* Hide the template preheader to save space */
+
+        #headerImage{
+          height:auto !important;
+          max-width:600px !important;
+          width:100% !important;
+        }
+
+        .headerContent{
+          font-size:20px !important;
+          line-height:125% !important;
+        }
+
+        .bodyContent{
+          font-size:18px !important;
+          line-height:125% !important;
+        }
+
+        .templateColumnContainer{display:block !important; width:100% !important;}
+
+        .columnImage{
+          height:auto !important;
+          max-width:480px !important;
+          width:100% !important;
+        }
+
+        .leftColumnContent{
+          font-size:16px !important;
+          line-height:125% !important;
+        }
+
+        .centerColumnContent{
+          font-size:16px !important;
+          line-height:125% !important;
+        }
+
+        .rightColumnContent{
+          font-size:16px !important;
+          line-height:125% !important;
+        }
+
+        .footerContent{
+          font-size:14px !important;
+          line-height:115% !important;
+        }
+
+        .footerContent a{display:block !important;} /* Place footer social and utility links on their own lines, for easier access */
+      }
+    </style>
+
+    <table align="center" border="0" cellpadding="0" cellspacing="0" id="bodyTable" style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #FAFAFA; border-collapse: collapse !important; height: 100% !important; margin: 0; mso-table-lspace: 0pt; mso-table-rspace: 0pt; padding: 0; width: 100% !important" width="100%">
+        <tr>
+            <td align="center" id="bodyCell" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; height: 100% !important; width: 100% !important; border-top-width: 4px; border-top-color: #dddddd; border-top-style: solid; margin: 0; padding: 20px;" valign="top"><!-- BEGIN TEMPLATE // --><table border="0" cellpadding="0" cellspacing="0" id="templateContainer" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important; width: 600px; border: 1px solid #dddddd;">
+                    <tr>
+                        <td align="center" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt;" valign="top"><!-- BEGIN PREHEADER // --><table border="0" cellpadding="0" cellspacing="0" id="templatePreheader" style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #FFFFFF; border-bottom-color: #CCCCCC; border-bottom-style: solid; border-bottom-width: 1px; border-collapse: collapse !important; mso-table-lspace: 0pt; mso-table-rspace: 0pt" width="100%">
+                                <tr>
+                                    <td pardot-region="preheader_content00" align="left" class="preheaderContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #808080; font-family: Helvetica; font-size: 10px; line-height: 12.5px; text-align: left; padding: 10px 20px;" valign="top">この領域を使用して、メールのコンテンツの短いティーザーを指定します。こちらのテキストは、一部のメールクライアントのプレビュー領域に表示されます。</td>
+
+                                    <td pardot-region="preheader_content01" align="left" class="preheaderContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #808080; font-family: Helvetica; font-size: 10px; line-height: 12.5px; text-align: left; padding: 10px 20px 10px 0;" valign="top" width="180">メールが正しく表示されませんか?<br /> <a href="{{View_Online}}" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #606060; font-weight: normal; text-decoration: underline;" target="_blank">ブラウザーで表示してください</a>。</td>
+                                </tr>
+                            </table><!-- // END PREHEADER --></td>
+                    </tr>
+
+                    <tr>
+                        <td align="center" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt;" valign="top"><!-- BEGIN HEADER // --><table border="0" cellpadding="0" cellspacing="0" id="templateHeader" style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #FFFFFF; border-bottom-color: #CCCCCC; border-bottom-style: solid; border-bottom-width: 1px; border-collapse: collapse !important; mso-table-lspace: 0pt; mso-table-rspace: 0pt" width="100%">
+                                <tr pardot-repeatable="">
+                                    <td pardot-region="header_image" align="left" class="headerContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 20px; font-weight: bold; line-height: 20px; text-align: left; vertical-align: middle; padding: 0;" valign="top"><img id="headerImage" src="/images/placeholder.php?width=600&amp;height=150" style="max-width: 600px; -ms-interpolation-mode: bicubic; height: auto; outline: none; text-decoration: none; border: 0;" alt="" /></td>
+                                </tr>
+                            </table><!-- // END HEADER --></td>
+                    </tr>
+
+                    <tr>
+                        <td align="center" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt;" valign="top"><!-- BEGIN BODY // --><table border="0" cellpadding="0" cellspacing="0" id="templateBody" style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #FFFFFF; border-bottom-color: #CCCCCC; border-bottom-style: solid; border-bottom-width: 1px; border-collapse: collapse !important; border-top-color: #FFFFFF; border-top-style: solid; border-top-width: 1px; mso-table-lspace: 0pt; mso-table-rspace: 0pt" width="100%">
+                                <tr pardot-repeatable="">
+                                    <td pardot-region="body_content" align="left" class="bodyContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 16px; line-height: 24px; text-align: left; padding: 20px;" valign="top">
+                                        <h1 style="color: #202020 !important; display: block; font-family: Helvetica; font-size: 26px; font-style: normal; font-weight: bold; letter-spacing: normal; line-height: 26px; margin: 0; padding-bottom:10px; text-align: left">テンプレートのデザイン</h1>
+
+                                        <h3 style="color: #606060 !important; display: block; font-family: Helvetica; font-size: 16px; font-style: italic; font-weight: normal; letter-spacing: normal; line-height: 16px; margin: 0; padding-bottom:10px; text-align: left">見栄えの良いメールを簡単に作成できます</h3>右側のスタイルエディターのタブをクリックして、テンプレートをカスタマイズします。フォント、色、スタイルを設定します。スタイルの設定が完了したら、この領域のこちらをクリックしてテキストを削除し、独自の素晴らしいコンテンツの追加を開始できます。<br /> <br /><h2 style="color: #404040 !important; display: block; font-family: Helvetica; font-size: 20px; font-style: normal; font-weight: bold; letter-spacing: normal; line-height: 20px; margin: 0; padding-bottom:10px; text-align: left">コンテンツのスタイル設定</h2>
+
+                                        <h4 style="color: #808080 !important; display: block; font-family: Helvetica; font-size: 14px; font-style: italic; font-weight: normal; letter-spacing: normal; line-height: 14px; margin: 0; padding-bottom:10px; text-align: left">メールを読みやすくする</h4>コンテンツを入力したら、スタイル設定するテキストを強調表示して、スタイルエディターの <em>[スタイル]</em> タブで設定したオプションを選択します。<a href="#" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #336699; font-weight: normal; text-decoration: underline;">テキストの一部のスタイル設定を解除</a>したいのに、問題が発生しますか? <em>[書式設定を削除]</em>ボタンを使用し、テキストの書式設定を削除してスタイルをリセットしてください。</td>
+                                </tr>
+                            </table><!-- // END BODY --></td>
+                    </tr>
+
+                    <tr>
+                        <td align="center" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt;" valign="top"><!-- BEGIN COLUMNS // --><table border="0" cellpadding="0" cellspacing="0" id="templateColumns" style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #FFFFFF; border-bottom-color: #CCCCCC; border-bottom-style: solid; border-bottom-width: 1px; border-collapse: collapse !important; border-top-color: #FFFFFF; border-top-style: solid; border-top-width: 1px; mso-table-lspace: 0pt; mso-table-rspace: 0pt" width="100%">
+                                <tr pardot-repeatable="">
+                                    <td align="center" class="templateColumnContainer" style="padding-top: 20px; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 200px;" valign="top">
+                                        <table border="0" cellpadding="20" cellspacing="0" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;" width="100%">
+                                            <tr>
+                                                <td pardot-region="left_content_image" align="left" class="leftColumnContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 14px; line-height: 21px; text-align: left; padding: 0 20px 20px;"><img class="columnImage" src="/images/placeholder.php?width=160&amp;height=120" style="max-width: 160px; -ms-interpolation-mode: bicubic; height: auto; outline: none; text-decoration: none; display: inline; border: 0;" alt="" /></td>
+                                            </tr>
+
+                                            <tr>
+                                                <td pardot-region="left_column_content" align="left" class="leftColumnContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 14px; line-height: 21px; text-align: left; padding: 0 20px 20px;" valign="top">
+                                                    <h3 style="color: #606060 !important; display: block; font-family: Helvetica; font-size: 16px; font-style: italic; font-weight: normal; letter-spacing: normal; line-height: 16px; margin: 0; padding-bottom:10px; text-align: left">繰り返し可能コンテンツ</h3><strong>繰り返し可能コンテンツブロック:</strong> 領域の右上にあるドロップ矢印の上にカーソルを置き、[コピー]、[行を上に移動]、[削除] など、そのセクションに固有のオプションのメニューを切り替えます。<a href="#" style="color: #336699; font-weight: normal; text-decoration: underline; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%;" target="_blank">少し装飾的にする</a>こともできます。ブロックを繰り返してテキストをすべて削除し、画像「ギャラリー」セクションを作成したり、その反対に画像を削除してテキスト専用ブロックを作成したりしてください。</td>
+                                            </tr>
+                                        </table>
+                                    </td>
+
+                                    <td align="center" class="templateColumnContainer" style="padding-top: 20px; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 200px;" valign="top">
+                                        <table border="0" cellpadding="20" cellspacing="0" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;" width="100%">
+                                            <tr>
+                                                <td pardot-region="center_column_image" align="left" class="centerColumnContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 14px; line-height: 21px; text-align: left; padding: 0 20px 20px;"><img class="columnImage" src="/images/placeholder.php?width=160&amp;height=120" style="max-width: 160px; -ms-interpolation-mode: bicubic; height: auto; outline: none; text-decoration: none; border: 0;" alt="" /></td>
+                                            </tr>
+
+                                            <tr>
+                                                <td pardot-region="center_column_content" align="left" class="centerColumnContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 14px; line-height: 21px; text-align: left; padding: 0 20px 20px;" valign="top">
+                                                    <h3 style="color: #606060 !important; display: block; font-family: Helvetica; font-size: 16px; font-style: italic; font-weight: normal; letter-spacing: normal; line-height: 16px; margin: 0; padding-bottom:10px; text-align: left">繰り返し可能コンテンツ</h3><strong>繰り返し可能コンテンツブロック:</strong> 領域の右上にあるドロップ矢印の上にカーソルを置き、[コピー]、[行を上に移動]、[削除] など、そのセクションに固有のオプションのメニューを切り替えます。<a href="#" style="color: #336699; font-weight: normal; text-decoration: underline; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%;" target="_blank">少し装飾的にする</a>こともできます。ブロックを繰り返してテキストをすべて削除し、画像「ギャラリー」セクションを作成したり、その反対に画像を削除してテキスト専用ブロックを作成したりしてください。</td>
+                                            </tr>
+                                        </table>
+                                    </td>
+
+                                    <td align="center" class="templateColumnContainer" style="padding-top: 20px; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; width: 200px;" valign="top">
+                                        <table border="0" cellpadding="20" cellspacing="0" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important;" width="100%">
+                                            <tr>
+                                                <td pardot-region="right_column_image" align="left" class="rightColumnContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 14px; line-height: 21px; text-align: left; padding: 0 20px 20px;"><img class="columnImage" src="/images/placeholder.php?width=160&amp;height=120" style="max-width: 160px; -ms-interpolation-mode: bicubic; height: auto; outline: none; text-decoration: none; display: inline; border: 0;" alt="" /></td>
+                                            </tr>
+
+                                            <tr>
+                                                <td pardot-region="right_column_content" align="left" class="rightColumnContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #505050; font-family: Helvetica; font-size: 14px; line-height: 21px; text-align: left; padding: 0 20px 20px;" valign="top">
+                                                    <h3 style="color: #606060 !important; display: block; font-family: Helvetica; font-size: 16px; font-style: italic; font-weight: normal; letter-spacing: normal; line-height: 16px; margin: 0; padding-bottom:10px; text-align: left">繰り返し可能コンテンツ</h3><strong>繰り返し可能コンテンツブロック:</strong> 領域の右上にあるドロップ矢印の上にカーソルを置き、[コピー]、[行を上に移動]、[削除] など、そのセクションに固有のオプションのメニューを切り替えます。<a href="#" style="color: #336699; font-weight: normal; text-decoration: underline; -webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%;" target="_blank">少し装飾的にする</a>こともできます。ブロックを繰り返してテキストをすべて削除し、画像「ギャラリー」セクションを作成したり、その反対に画像を削除してテキスト専用ブロックを作成したりしてください。</td>
+                                            </tr>
+                                        </table>
+                                    </td>
+                                </tr>
+                            </table><!-- // END COLUMNS --></td>
+                    </tr>
+
+                    <tr>
+                        <td align="center" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt;" valign="top"><!-- BEGIN FOOTER // --><table border="0" cellpadding="0" cellspacing="0" id="templateFooter" style="-ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; background-color: #FFFFFF; border-collapse: collapse !important; border-top-color: #FFFFFF; border-top-style: solid; border-top-width: 1px; mso-table-lspace: 0pt; mso-table-rspace: 0pt" width="100%">
+                                <tr pardot-removable="">
+                                    <td pardot-region="footer_content00" align="left" class="footerContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #808080; font-family: Helvetica; font-size: 10px; line-height: 15px; text-align: left; padding: 20px;" valign="top"><a href="#" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #606060; font-weight: normal; text-decoration: underline;">Twitter でフォロー</a>&nbsp;&nbsp;&nbsp;<a href="#" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #606060; font-weight: normal; text-decoration: underline;">Facebook の友達</a>&nbsp;&nbsp;&nbsp;<a href="{{addthis_url_email}}" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #606060; font-weight: normal; text-decoration: underline;">友達に転送</a>&nbsp;</td>
+                                </tr>
+
+                                <tr>
+                                    <td pardot-region="footer_content01" align="left" class="footerContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #808080; font-family: Helvetica; font-size: 10px; line-height: 15px; text-align: left; padding: 0 20px 20px;" valign="top"><em>Copyright © {{Current_Year}}, All rights reserved.</em><br /> <br /> <strong>住所:</strong><br /> {{{Organization.Address}}}</td>
+                                </tr>
+
+                                <tr>
+                                    <td pardot-region="footer_content02" align="left" class="footerContent" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; mso-table-lspace: 0pt; mso-table-rspace: 0pt; color: #808080; font-family: Helvetica; font-size: 10px; line-height: 15px; text-align: left; padding: 0 20px 20px;" valign="top"><a href="{{Unsubscribe}}" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #606060; font-weight: normal; text-decoration: underline;">すべてのメールの登録解除</a>&nbsp;&nbsp;&nbsp;<a href="{{{EmailPreferenceCenter}}}" style="-webkit-text-size-adjust: 100%; -ms-text-size-adjust: 100%; color: #606060; font-weight: normal; text-decoration: underline;">サブスクリプション設定の更新</a>&nbsp;</td>
+                                </tr>
+                            </table><!-- // END FOOTER --></td>
+                    </tr>
+                </table><!-- // END TEMPLATE --></td>
+        </tr>
+    </table><br /> <!--
+          This email was originally designed by the wonderful folks at MailChimp and remixed by Pardot.
+          It is licensed under CC BY-SA 3.0
+        --></body>
+</html>


### PR DESCRIPTION
The 3-column responsive HML layout was still missing from en_US, de_DE, es_ES, and ja_JP; as such, it's probably also missing from pt_BR. Once the Portuguese layouts are added in production, an HML version can be created and added to this repo.